### PR TITLE
DM-45945: Add UWS specification, flesh out other details

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -187,6 +187,10 @@ delete
 action
     Requests that the server perform some action that does not directly correspond to creating, modifying, deleting, or querying an object.
 
+Operations of type query and delete may have an empty request body.
+All other types of operations should have a non-empty request body in the service specification.
+This avoids some security issues with HTTP-based network encodings.
+
 .. _responses:
 
 Responses

--- a/index.rst
+++ b/index.rst
@@ -206,6 +206,15 @@ Web service specifications should list the MIME types of the possible data respo
 The network protocol encoding must describe how to receive a data response and determine its MIME type, but need not describe how it is encoded if the network protocol conveys the normal byte stream representation of that MIME type in a way that is understood by a normal client of that network protocol.
 For example, a network protocol specification built on top of HTTP need not specify how HTTP conveys ``application/fits`` data, only how to label that the response is ``application/fits``.
 
+Content negotiation for data responses
+--------------------------------------
+
+Operations that respond with data may support multiple formats for that data.
+Network protocols may provide a protocol mechanism for the client to request which format should be used for the data response.
+For example, HTTP-based protocols may use the ``Accept`` HTTP header and corresponding content negotiation protocol to determine the requested format for the data response.
+
+Not all network protocols provide a protocol-level way of negotiating the format, so service specifications may also provide a way to ask for a specific data format as part of the request.
+
 Errors
 ======
 

--- a/index.rst
+++ b/index.rst
@@ -377,12 +377,11 @@ Create job
 Create a new job.
 By default, the job is created in the ``PENDING`` phase.
 
-.. list-table::
+Path
+    ``./``
 
-   * - Path
-     - ./
-   * - Operation type
-     - create
+Operation type
+    create
 
 Parameters
 """"""""""
@@ -416,6 +415,55 @@ Response
 On successful creation of the job, returns a response of type job, containing the metadata about the newly-created job.
 This may be done via a redirect to the :ref:`Get job <uws-get-job>` operation.
 
+List jobs
+^^^^^^^^^
+
+Retrieve a list of jobs.
+
+Path
+    ``jobs``
+
+Operation type
+    query
+
+``GET`` may be used in the JSON network encoding.
+
+Parameters
+""""""""""
+
+phase (list of phase, optional, plural: phases)
+    Limit returned jobs to those in one of the given phases.
+
+after (timestamp, optional)
+    Limit returned jobs to those created after the given timestamp.
+
+last (integer, optional)
+    Limit returned jobs to the given number of records, prefering the most recent.
+    This limit is applied after other filtering.
+    For example, if both ``phase`` and ``after`` are given, along with ``limit=50``, this is a request for the 50 most recent jobs that satisfy the phase and creation timestamp constraints.
+
+Response
+""""""""
+
+On success, returns a list of objects representing jobs, sorted by descending creation time.
+Each object has the following labels.
+
+job (uri)
+    URL to a job record.
+    This should be the URL of the :ref:`uws-get-job` API that retrieves the job corresponding to this object.
+
+owner (string, optional)
+    Identity of the owner of the job, if the job is owned by a specific user.
+
+phase (phase)
+    Execution phase of the job.
+
+runId (string, optional)
+    The run ID provided by the client when creating the job, if any.
+
+creationTime (timestamp)
+    When the job was created.
+
 .. _uws-get-job:
 
 Get job
@@ -423,12 +471,11 @@ Get job
 
 Retrieve the details of a job.
 
-.. list-table::
+Path
+    ``jobs/{jobId}``
 
-   * - Path
-     - jobs/{jobId}
-   * - Operation type
-     - query
+Operation type
+    query
 
 ``GET`` may be used in the JSON network encoding.
 
@@ -447,12 +494,11 @@ Start job
 
 Requests that the server start the execution of the job.
 
-.. list-table::
+Path
+    ``jobs/{jobId}/start``
 
-   * - Path
-     - jobs/{jobId}/start
-   * - Operation type
-     - action
+Operation type
+    action
 
 Parameters
 """"""""""
@@ -466,17 +512,48 @@ Response
 If the job with ID ``jobId`` can be started successfully, returns a response of type job, containing the metadata for that job.
 This may be done via a redirect to the :ref:`Get job <uws-get-job>` operation.
 
+Wait for job
+^^^^^^^^^^^^
+
+Wait for the phase of a job to change.
+
+Path
+    ``jobs/{jobId}/wait``
+
+Operation type
+    query
+
+``GET`` may be used in the JSON network encoding.
+
+Parameters
+""""""""""
+
+phase (phase)
+    The phase that the client thinks the job is in.
+    The server will return as soon as the job phase is different from this phase, including when the phase of the job is already different when the request was received.
+
+timeout (duration, optional)
+    How long to wait for a phase transition.
+    If not given, the server will impose a maximum timeout.
+    This should be chosen by the server to be consistent with the native low-level timeout of the network protocol in use, if that imposes any constraints.
+
+Response
+""""""""
+
+When the job with ID ``jobId`` has a phase different from the provided phase, or when the timeout expires, returns a response of type job, containing the metadata for that job.
+The server will also return the job immediately if the phase is anything other than ``PENDING``, ``QUEUED``, ``EXECUTING``, ``HELD``, or ``SUSPENDED``, even if it matches the provided phase, since the other phases are terminal phases and will generally not change within the timeout of a query.
+This may be done via a redirect to the :ref:`Get job <uws-get-job>` operation.
+
 Modify job
 ^^^^^^^^^^
 
 Modify the parameters of an existing job.
 
-.. list-table::
+Path
+    ``jobs/{jobId}``
 
-   * - Path
-     - jobs/{jobId}
-   * - Operation type
-     - modify
+Operation type
+    modify
 
 Delete job
 ^^^^^^^^^^
@@ -486,12 +563,11 @@ The job is stopped if it is currently running and removed from the API.
 It is not specified whether the underlying data associated with the job is deleted or merely made inaccessible.
 Deletion may not happen immediately.
 
-.. list-table::
+Path
+    ``jobs/{jobId}``
 
-   * - Path
-     - jobs/{jobId}
-   * - Operation type
-     - delete
+Operation type
+    delete
 
 Parameters
 """"""""""
@@ -539,12 +615,11 @@ If the web service uses the UWS pattern, it can refer to :ref:`uws` for its supp
 To do
 =====
 
-The following things should be part of this specification but have not yet been written:
+The following things should be part of this draft specification but have not yet been written:
 
 .. rst-class:: compact
 
 - Address the various notes scattered through the document.
-- A specification for the Universal Worker Service API.
 - Descriptions of errors common to many web services, in a form suitable for creating URLs that serve as error identifiers.
 - Add the VOSI availability API
 - Add the VOSI capabilities API, which requires writing a data model for registry entries or continuing to return the current XML data model.

--- a/index.rst
+++ b/index.rst
@@ -271,6 +271,237 @@ This allows a web service to return multiple errors in the same response, such a
 
 This structured error message may be used outside of explicit error responses.
 For example, it may be an appropriate data type for an error field in an object that provides the results of some previous operation.
+It is referred to as the data type ``error``.
+
+.. _uws:
+
+Universal Worker Service
+========================
+
+Many IVOA services perform operations that take longer than the typical timeout on a network protocol request and response.
+The Universal Worker Service (UWS) pattern is a standardized way to write such a service.
+All services implementing UWS use the same data model and operations to create and manage potentially long-running jobs and retrieve their results.
+
+.. note::
+
+   It may make more sense to spin this off as a separate document.
+   The formal specification should include all of the other semantic detail from the UWS specification, such as the state model.
+
+Data types
+----------
+
+phase (enum)
+    The current execution phase of the job.
+    One of the following values:
+
+    - ``PENDING``
+    - ``QUEUED``
+    - ``EXECUTING``
+    - ``COMPLETED``
+    - ``ERROR``
+    - ``ABORTED``
+    - ``UNKNOWN``
+    - ``HELD``
+    - ``SUSPENDED``
+    - ``ARCHIVED``
+
+job (object)
+    A representation of a UWS job.
+    It has the following fields:
+
+    jobId (string)
+        Unique identifier of the job.
+
+    owner (string, optional)
+        Identity of the owner of the job, if the job is owned by a specific user.
+
+    phase (phase)
+        Execution phase of the job.
+
+    runId (string, optional)
+        The run ID provided by the client when creating the job, if any.
+
+    creationTime (timestamp)
+        When the job was created.
+
+    startTime (timestamp, optional)
+        When the job started executing, if it has.
+
+    endTime (timestamp, optional)
+        When the job finished executing, if it has.
+
+    destructionTime (timestamp, optional)
+        When the job will be destroyed and any resources allocated to it will be freed.
+        When this time is reached, the job will be stopped if it is still running, all stored results and other information will be freed, and the service will forget that the job existed.
+
+    executionDuration (duration, optional)
+        How long the job is allowd to run.
+        If this is set and the job runs for longer than this period, it will be aborted.
+
+    quote (timestamp, optional)
+        Estimated time of completion of the job if it were started now.
+        If this time is later than ``destructionTime``, job execution is not possible due to resource constraints.
+
+    parameters (object)
+        The parameters used to create the job.
+        The data type of this object is defined by the service specification.
+
+    error (list of error, plural: errors, optional)
+        If the job failed with an error, the error messages corresponding to the failure.
+        This is a list so that all of the errors can be recorded for jobs that failed for multiple reasons.
+
+    result (list of object, plural: results, optional)
+        The results from the job, if it executed successfully.
+        The labels in each object are:
+
+        url (uri)
+            URL pointing to the job result.
+            This URL can be requested by the client (with ``GET``) to obtain the results of the job.
+
+        size (integer, optional)
+            The size of the results returned by ``uri``, if known.
+
+        mimeType (string, optional)
+            The MIME type of the results.
+            This should match the ``Content-Type`` header returned by ``GET`` on ``uri``.
+
+Operations
+----------
+
+The paths of these operations are relative to the base path of the UWS API, as defined by the service specification.
+This may not be the same as the base path of the service's API.
+
+Create job
+^^^^^^^^^^
+
+Create a new job.
+By default, the job is created in the ``PENDING`` phase.
+
+.. list-table::
+
+   * - Path
+     - ./
+   * - Operation type
+     - create
+
+Parameters
+""""""""""
+
+parameters (object)
+    The parameters to the job.
+    The data model for this parameter must be defined by the service specification.
+
+executionDuration (duration, optional)
+    Set the execution duration for the job.
+    Jobs will be aborted if they run for longer than this duration.
+    The server may override the value requested by the client, so the client must check the ``executionDuration`` of the returned job record to see what value was set.
+
+destructionTime (timestamp, optional)
+    The time at which the job and all of its results are deleted.
+    The job is aborted if it is still running, and all record of the job is removed.
+    The server may override the value requested by the client, so the client must check the ``executionDuration`` of the returned job record to see what value was set.
+
+runId (string, optional)
+    A run ID to associate with the job.
+    The server stores this as an opaque string and returns it in job records.
+    It may be used by the client to associate several jobs together or make it easier to find specific jobs later.
+
+start (boolean, optional)
+    If included and set to true, attempt to immediately start the job.
+    By default, a newly-created job stays in ``PENDING`` phase until it is explicitly started.
+
+Response
+""""""""
+
+On successful creation of the job, returns a response of type job, containing the metadata about the newly-created job.
+This may be done via a redirect to the :ref:`Get job <uws-get-job>` operation.
+
+.. _uws-get-job:
+
+Get job
+^^^^^^^
+
+Retrieve the details of a job.
+
+.. list-table::
+
+   * - Path
+     - jobs/{jobId}
+   * - Operation type
+     - query
+
+``GET`` may be used in the JSON network encoding.
+
+Parameters
+""""""""""
+
+None.
+
+Response
+""""""""
+
+If the job with the ``jobId`` specified in the path is found and the user is authorized, returns a response of type job containing the metadata about that job.
+
+Start job
+^^^^^^^^^
+
+Requests that the server start the execution of the job.
+
+.. list-table::
+
+   * - Path
+     - jobs/{jobId}/start
+   * - Operation type
+     - action
+
+Parameters
+""""""""""
+
+start (boolean)
+    Must be set to true.
+
+Response
+""""""""
+
+If the job with ID ``jobId`` can be started successfully, returns a response of type job, containing the metadata for that job.
+This may be done via a redirect to the :ref:`Get job <uws-get-job>` operation.
+
+Modify job
+^^^^^^^^^^
+
+Modify the parameters of an existing job.
+
+.. list-table::
+
+   * - Path
+     - jobs/{jobId}
+   * - Operation type
+     - modify
+
+Delete job
+^^^^^^^^^^
+
+Deletes a job.
+The job is stopped if it is currently running and removed from the API.
+It is not specified whether the underlying data associated with the job is deleted or merely made inaccessible.
+Deletion may not happen immediately.
+
+.. list-table::
+
+   * - Path
+     - jobs/{jobId}
+   * - Operation type
+     - delete
+
+Parameters
+""""""""""
+
+None.
+
+Response
+""""""""
+
+On success, none apart from the status code indicating success.
 
 Specification contents
 ======================
@@ -302,6 +533,8 @@ Web service specifications must include all of the following:
 #. For each supported network protocol encoding, the information that the network protocol says should be provided.
    This will usually include some form of schema for the combination of the web service and the network protocol.
    Requiring a schema is highly recommended, since schemas allow for code generation, service validation, and automatic generation of documentation.
+
+If the web service uses the UWS pattern, it can refer to :ref:`uws` for its supported operations and need only specify the data type for job parameters, the semantics of the job, the possible results of the job, and any additional service operations that fall outside the UWS pattern.
 
 To do
 =====

--- a/index.rst
+++ b/index.rst
@@ -81,27 +81,16 @@ The following data types may be used for object values in web service specificat
 A web service specification should indicate the data type of every value in an object.
 A network protocol specification must describe how to serialize and deserialize these data types when sending them as part of a request or response.
 
-object
-    A mapping of labels to values.
-    Each object must have a specification for its acceptable labels and values, and each such specified object is considered a separate data type.
-    Labels themselves are of type string (defined below).
-    Every value corresponding to a label must have a specified data type.
-    Labels may be optional, in which case the absence of the label and value or the presence of the label with a null value are equivalent.
+Primitive data types
+--------------------
 
-null
-    The null value, indicating no value is present.
-    If the value of a label within an object is null, this is equivalent to omitting the label and its value entirely.
-    Web service specifications will generally not define values as having the null type and instead specify that the corresponding label is optional, which means that it may either have a valid value of its specified type or may be null.
-    Network protocol specifications must specify how to serialize and deserialize null values.
+boolean
+    A value that accepts only two options, true or false.
 
-string
-    A sequence of Unicode code points.
-    By default, this sequence is allowed to be empty.
-    If this is not permitted for a given value, the web service must specify this.
-
-uri
-    A Uniform Resource Identifier as specified in :rfc:`3986`.
-    If there are any constraints on its contents, such as a specific schema or structure, this must be specified by the web service.
+duration
+    A time duration.
+    By default, the duration has second precision and a millisecond portion of all zeroes should not be interpreted as providing additional precision.
+    Optionally, the web service specification may state that the milliseconds are significant.
 
 integer
     An integer number with an optional sign.
@@ -110,19 +99,23 @@ integer
     The web service specification should state the valid range if it is different than this.
     Values outside the default range may create encoding problems for some network protocols.
 
-float
-    A floating point number.
+null
+    The null value, indicating no value is present.
+    If the value of a label within an object is null, this is equivalent to omitting the label and its value entirely.
+    Web service specifications will generally not define values as having the null type and instead specify that the corresponding label is optional, which means that it may either have a valid value of its specified type or may be null.
+    Network protocol specifications must specify how to serialize and deserialize null values.
+
+real
+    A real number.
     By default, any IEEE 754 binary64 (double precision) floating point number is supported.
     The web service specification should state any additional constraints.
     By default, the values positive infinity, negative infinity, and NaN are not permitted.
     The web service specification may explicitly allow them, but then must state their intended meanings in the context of the web service.
 
-boolean
-    A value that accepts only two options, true or false.
-
-enum
-    A value that must be chosen from an enumerated list of possibilities specified in the web service specification.
-    Each possibility must be a string.
+string
+    A sequence of Unicode code points.
+    By default, this sequence is allowed to be empty.
+    If this is not permitted for a given value, the web service must specify this.
 
 timestamp
     A specific point in UTC time using the Gregorian calendar.
@@ -131,10 +124,19 @@ timestamp
     Precision greater than milliseconds is not supported in timestamp fields and should be represented using some other data type (generally integer or float) following a specification specific to that web service.
     Dates prior to 1582-10-15 should not use this data type since they predate the Gregorian calendar.
 
-duration
-    A time duration.
-    By default, the duration has second precision and a millisecond portion of all zeroes should not be interpreted as providing additional precision.
-    Optionally, the web service specification may state that the milliseconds are significant.
+Derived data types
+------------------
+
+enum
+    A value that must be chosen from an enumerated list of possibilities specified in the web service specification.
+    Each possibility must be a string.
+
+uri
+    A Uniform Resource Identifier as specified in :rfc:`3986`.
+    If there are any constraints on its contents, such as a specific schema or structure, this must be specified by the web service.
+
+Composite data types
+--------------------
 
 list
     A list of some other data type.
@@ -144,6 +146,13 @@ list
     By default, a list may be empty.
     If it must be non-empty, the web service specification must specify this.
     The specification for the label for a value of type list must include both the singular and plural form, since different network encodings will use either the singular or the plural or both in different contexts.
+
+object
+    A mapping of labels to values.
+    Each object must have a specification for its acceptable labels and values, and each such specified object is considered a separate data type.
+    Labels themselves are of type string.
+    Every value corresponding to a label must have a specified data type.
+    A given label and its value may be optional, in which case the absence of the label and value or the presence of the label with a null value are equivalent.
 
 Operations
 ==========

--- a/index.rst
+++ b/index.rst
@@ -226,6 +226,8 @@ For example, HTTP-based protocols may use the ``Accept`` HTTP header and corresp
 
 Not all network protocols provide a protocol-level way of negotiating the format, so service specifications may also provide a way to ask for a specific data format as part of the request.
 
+.. _errors:
+
 Errors
 ======
 
@@ -364,6 +366,11 @@ job (object)
         mimeType (string, optional)
             The MIME type of the results.
             This should match the ``Content-Type`` header returned by ``GET`` on ``uri``.
+
+        error (boolean, optional)
+            If present and set to true, indicates that this result is an error.
+            The service specification specifies the type and content of the error.
+            Service specifications are encouraged to use an encoding of the object defined in :ref:`errors`.
 
 Operations
 ----------

--- a/index.rst
+++ b/index.rst
@@ -191,6 +191,17 @@ Operations of type query and delete may have an empty request body.
 All other types of operations should have a non-empty request body in the service specification.
 This avoids some security issues with HTTP-based network encodings.
 
+Operation paths
+---------------
+
+Operations have an associated path.
+This is a relative-URL string that specifies the URL for this operation relative to the base URL for the deployed service.
+It is only applicable to network protocols that use URLs.
+
+Multiple operations may have the same path.
+In this case, they must have different operation types.
+Operations of type action may not share the same path with any other operation.
+
 .. _responses:
 
 Responses


### PR DESCRIPTION
Add a UWS specification that can be reused by various services.

Restructure the list of types to hopefully be more readable. Add a mention of content negotiation. Disallow empty request bodies for some operations.